### PR TITLE
Fix bug in closed array projection

### DIFF
--- a/ballerina/tests/fromXml_test.bal
+++ b/ballerina/tests/fromXml_test.bal
@@ -530,6 +530,40 @@ function testXmlStringToRecord41() returns error? {
     test:assertEquals(rec2.A[1], 2);
 }
 
+@Namespace {
+    uri: "http://www.example.com/invoice",
+    prefix: "inv"
+}
+@Name {
+    value: "invoice"
+}
+type DataProj5 record {|
+    DataProjField customers;
+|};
+
+type DataProjField record {|
+    @Name {
+        value: "customer"
+    }
+    string[2] cust;
+|};
+
+@test:Config
+function testXmlStringToRecord42() returns error? {
+string xmlStr = string `<inv:invoice xmlns:inv="http://www.example.com/invoice">
+    <customers>
+        <customer>KLLBCQVN0Y</customer>
+        <customer>T8VQU3X0QH</customer>
+        <customer>DAWQU3X0QH</customer>
+    </customers>
+    </inv:invoice>`;
+
+    DataProj5 invoice = check fromXmlStringWithType(xmlStr);
+    test:assertEquals(invoice.customers.cust.length(), 2);
+    test:assertEquals(invoice.customers.cust[0], "KLLBCQVN0Y");
+    test:assertEquals(invoice.customers.cust[1], "T8VQU3X0QH");
+}
+
 // Negative cases
 type DataN1 record {|
     int A;

--- a/ballerina/tests/stream_large_file_test.bal
+++ b/ballerina/tests/stream_large_file_test.bal
@@ -57,7 +57,7 @@ const LARGE_XML_FILE = "build//resources//large_data.xml";
 # Test reading large xml file with namespaces.
 # + return - return error on failure, else nil.
 @test:Config {
-    enable: false
+    enable: true
 }
 function testLargeFileStreamWithNamespace() returns error? {
     stream<byte[], error?> dataStream = check io:fileReadBlocksAsStream(LARGE_XML_FILE);
@@ -93,14 +93,14 @@ type SimpleCustomer record {|
 # Test reading large xml file without considering namespaces.
 # + return - return error on failure, else nil.
 @test:Config {
-    enable: false
+    enable: true
 }
 function testLargeFileStream() returns error? {
     stream<byte[], error?> dataStream = check io:fileReadBlocksAsStream(LARGE_XML_FILE);
     SimpleInvoice invoice = check fromXmlStringWithType(dataStream);
 
     test:assertEquals(invoice.customers.length(), 1, "Invalid number of customers fields");
-    test:assertEquals(invoice.customers.customer.length(), 100000, "Invalid customers/customer length");
+    test:assertEquals(invoice.customers.customer.length(), 100001, "Invalid customers/customer length");
     test:assertEquals(invoice.customers.customer[0].length(), 3, "Invalid customers/customer/[0] fields");
 
     test:assertEquals(invoice.customers.customer[0].id, 0, "Invalid customers/customer/[0]/id");

--- a/native/src/main/java/io/ballerina/stdlib/data/xml/XmlParser.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/xml/XmlParser.java
@@ -356,16 +356,19 @@ public class XmlParser {
 
         for (String key : xmlParserData.fieldHierarchy.peek().keySet()) {
             // Validate required array size
-            if (xmlParserData.fieldHierarchy.peek().get(key).getFieldType().getTag() == TypeTags.ARRAY_TAG) {
-                ArrayType arrayType = (ArrayType) xmlParserData.fieldHierarchy.peek().get(key).getFieldType();
+            Field field = xmlParserData.fieldHierarchy.peek().get(key);
+            String fieldName = field.getFieldName();
+            if (field.getFieldType().getTag() == TypeTags.ARRAY_TAG) {
+                ArrayType arrayType = (ArrayType) field.getFieldType();
                 if (arrayType.getSize() != -1
-                        && arrayType.getSize() != ((BArray) currentNode.get(StringUtils.fromString(key))).getLength()) {
+                        && arrayType.getSize() != ((BArray) currentNode.get(
+                                StringUtils.fromString(fieldName))).getLength()) {
                     throw DataUtils.getXmlError("Array size is not compatible with the expected size");
                 }
             }
 
-            if (!siblingKeys.contains(xmlParserData.modifiedNamesHierarchy.peek().getOrDefault(key, key))) {
-                throw DataUtils.getXmlError("Required field " + key + " not present in XML");
+            if (!siblingKeys.contains(xmlParserData.modifiedNamesHierarchy.peek().getOrDefault(fieldName, fieldName))) {
+                throw DataUtils.getXmlError("Required field " + fieldName + " not present in XML");
             }
         }
     }


### PR DESCRIPTION
Fix CCE for below case 

```
import ballerina/io;

@Namespace {
    uri: "http://www.example.com/invoice",
    prefix: "inv"
}
@Name {
    value: "invoice"
}
type DataProj5 record {|
    DataProjField customers;
|};

type DataProjField record {|
    @Name {
        value: "customer"
    }
    string[2] cust;
|};


public function main() returns error? {
    string xmlStr = string `<inv:invoice xmlns:inv="http://www.example.com/invoice">
    <customers>
        <customer>KLLBCQVN0Y</customer>
        <customer>T8VQU3X0QH</customer>
    </customers>
    </inv:invoice>`;

    DataProj5 invoice = check fromXmlStringWithType(xmlStr);
    io:println(invoice);
}
```