### PR TITLE
Support same element and attribute names with different namespaces

### DIFF
--- a/ballerina/tests/fromXml_test.bal
+++ b/ballerina/tests/fromXml_test.bal
@@ -26,7 +26,19 @@ type Data record {|
 
 @test:Config{}
 function testXmlStringToRecord1() returns error? {
-    string xmlStr = "<Data><A><B>1</B><B>2</B><C>6</C></A><D>5</D><A><B>3</B><B>4</B><C>5</C></A></Data>";
+    string xmlStr = string `<Data>
+        <A>
+            <B>1</B>
+            <B>2</B>
+            <C>6</C>
+        </A>
+        <D>5</D>
+        <A>
+            <B>3</B>
+            <B>4</B>
+            <C>5</C>
+        </A>
+    </Data>`;
     Data rec1 = check fromXmlStringWithType(xmlStr);
 
     test:assertEquals(rec1.A.length(), 2);
@@ -1302,14 +1314,14 @@ type DataN7 record {|
 function testXmlStringToRecordNegative9() {
     string xmlStr1 = string `<Data xmlns:ns1="www.test.com"><ns1:A>1</ns1:A></Data>`;
     DataN7|error rec1 = fromXmlStringWithType(xmlStr1);
-    test:assertEquals((<error>rec1).message(), "namespace mismatched for the field: A");
+    test:assertEquals((<error>rec1).message(), "Required field 'A' not present in XML");
 }
 
 @test:Config{}
 function testXmlToRecordNegative9() {
     xml xmlVal1 = xml `<Data xmlns:ns1="www.test.com"><ns1:A>1</ns1:A></Data>`;
     DataN7|error rec1 = fromXmlWithType(xmlVal1);
-    test:assertEquals((<error>rec1).message(), "namespace mismatched for the field: A");
+    test:assertEquals((<error>rec1).message(), "Required field 'A' not present in XML");
 }
 
 @Namespace {
@@ -1327,14 +1339,14 @@ type DataN8 record {|
 function testXmlStringToRecordNegative10() {
     string xmlStr1 = string `<x:foo xmlns:x="example.com"><x:bar>1</x:bar></x:foo>`;
     DataN8|error rec1 = fromXmlStringWithType(xmlStr1);
-    test:assertEquals((<error>rec1).message(), "namespace mismatched for the field: bar");
+    test:assertEquals((<error>rec1).message(), "Required field 'bar' not present in XML");
 }
 
 @test:Config{}
 function testXmlToRecordNegative10() {
     xml xmlVal1 = xml `<x:foo xmlns:x="example.com"><x:bar>1</x:bar></x:foo>`;
     DataN8|error rec1 = fromXmlWithType(xmlVal1);
-    test:assertEquals((<error>rec1).message(), "namespace mismatched for the field: bar");
+    test:assertEquals((<error>rec1).message(), "Required field 'bar' not present in XML");
 }
 
 @Namespace {
@@ -1358,14 +1370,14 @@ type DataN9 record {|
 function testXmlStringToRecordNegative11() {
     string xmlStr1 = string `<x:foo xmlns:x="example.com" xmlns="example2.com"><x:bar><baz>2</baz></x:bar></x:foo>`;
     DataN9|error rec1 = fromXmlStringWithType(xmlStr1);
-    test:assertEquals((<error>rec1).message(), "namespace mismatched for the field: baz");
+    test:assertEquals((<error>rec1).message(), "Required field 'baz' not present in XML");
 }
 
 @test:Config{}
 function testXmlToRecordNegative11() {
     xml xmlVal1 = xml `<x:foo xmlns:x="example.com" xmlns="example2.com"><x:bar><baz>2</baz></x:bar></x:foo>`;
     DataN9|error rec1 = fromXmlWithType(xmlVal1);
-    test:assertEquals((<error>rec1).message(), "namespace mismatched for the field: baz");
+    test:assertEquals((<error>rec1).message(), "Required field 'baz' not present in XML");
 }
 
 @test:Config{}

--- a/ballerina/tests/fromXml_test.bal
+++ b/ballerina/tests/fromXml_test.bal
@@ -1108,6 +1108,47 @@ function testOptionalFieldInXmlConversion() returns error? {
     test:assertEquals(rec2.B, "2");
 }
 
+type RecNs2 record {|
+    @Namespace {
+        prefix: "x",
+        uri: "example.com"
+    }
+    string bar;
+    @Name {
+        value: "bar"
+    }
+    @Namespace {
+        prefix: "y",
+        uri: "example2.com"
+    }
+    string baz;
+|};
+
+@test:Config{}
+function testSameElementWithDifferentNameSpace() returns error? {
+    string xmlStr = string `<x:foo xmlns:x="example.com" xmlns:y="example2.com" ><x:bar>1</x:bar><y:bar>2</y:bar></x:foo>`;
+    RecNs2 rec = check fromXmlStringWithType(xmlStr);
+    test:assertEquals(rec.bar, "1");
+    test:assertEquals(rec.baz, "2");
+
+    xml xmlVal = xml `<x:foo xmlns:x="example.com" xmlns:y="example2.com" ><x:bar>1</x:bar><y:bar>2</y:bar></x:foo>`;
+    RecNs2 rec2 = check fromXmlWithType(xmlVal);
+    test:assertEquals(rec2.bar, "1");
+    test:assertEquals(rec2.baz, "2");
+}
+
+@test:Config{}
+function testSameAttributeWithDifferentNameSpace() returns error? {
+    string xmlStr = string `<x:foo xmlns:x="example.com" xmlns:y="example2.com" x:bar="1" y:bar="2"></x:foo>`;
+    RecNs2 rec = check fromXmlStringWithType(xmlStr);
+    test:assertEquals(rec.bar, "1");
+    test:assertEquals(rec.baz, "2");
+
+    xml xmlVal = xml `<x:foo xmlns:x="example.com" xmlns:y="example2.com" x:bar="1" y:bar="2"></x:foo>`;
+    RecNs2 rec2 = check fromXmlWithType(xmlVal);
+    test:assertEquals(rec2.bar, "1");
+    test:assertEquals(rec2.baz, "2");
+}
 
 // Negative cases
 type DataN1 record {|

--- a/ballerina/tests/fromXml_test.bal
+++ b/ballerina/tests/fromXml_test.bal
@@ -1459,6 +1459,22 @@ function testXmlWithAttributesAgainstOpenRecord3() returns error? {
     ]);
 }
 
+@test:Config{}
+function testCommentMiddleInContent() returns error? {
+    string xmlStr = string `<Data>
+                                <A>John<!-- firstname --> Doe<!-- lastname --></A>
+                            </Data>`;
+    record {} rec = check fromXmlStringWithType(xmlStr);
+    test:assertEquals(rec.length(), 1);
+    test:assertEquals(rec.get("A"), "John Doe");
+
+    record {|
+        string A;
+    |} rec2 = check fromXmlStringWithType(xmlStr);
+    test:assertEquals(rec2.length(), 1);
+    test:assertEquals(rec2.A, "John Doe");
+}
+
 // Negative cases
 type DataN1 record {|
     int A;

--- a/ballerina/tests/fromXml_test.bal
+++ b/ballerina/tests/fromXml_test.bal
@@ -244,6 +244,41 @@ function testXmlToRecord5() returns error? {
     test:assertEquals(rec1.A[1].C, "2");
 }
 
+type Data8 record {|
+    int A;
+    int[] B;
+|};
+
+@test:Config{}
+function testXmlStringToRecord9() returns error? {
+    string xmlStr1 = string `
+    <Data>
+        <A>1</A>
+        <B>1</B>
+        <B>2</B>
+    </Data>`;
+    Data8 rec1 = check fromXmlStringWithType(xmlStr1);
+    test:assertEquals(rec1.A, 1);
+    test:assertEquals(rec1.B.length(), 2);
+    test:assertEquals((<int[]>rec1.B)[0], 1);
+    test:assertEquals((<int[]>rec1.B)[1], 2);
+}
+
+@test:Config{}
+function testXmlToRecord9() returns error? {
+    xml xmlVal = xml `
+    <Data>
+        <A>1</A>
+        <B>1</B>
+        <B>2</B>
+    </Data>`;
+    Data8 rec1 = check fromXmlWithType(xmlVal);
+    test:assertEquals(rec1.A, 1);
+    test:assertEquals(rec1.B.length(), 2);
+    test:assertEquals((<int[]>rec1.B)[0], 1);
+    test:assertEquals((<int[]>rec1.B)[1], 2);
+}
+
 // test for name annotations
 
 @Name {
@@ -478,7 +513,8 @@ type RecRest6 record {|
     int[]...;
 |};
 
-public function testXmlStringToRecord26() returns error? {
+@test:Config{}
+function testXmlStringToRecord26() returns error? {
     string xmlStr = string `
     <Data>
         <A>1</A>
@@ -491,7 +527,8 @@ public function testXmlStringToRecord26() returns error? {
     test:assertEquals((<int[]>rec.get("B"))[1], 3);
 }
 
-public function testXmlToRecord26() returns error? {
+@test:Config{}
+function testXmlToRecord26() returns error? {
     xml xmlVal = xml `<Data>
         <A>1</A>
         <B>2</B>
@@ -501,6 +538,86 @@ public function testXmlToRecord26() returns error? {
     test:assertEquals(rec.A, 1);
     test:assertEquals((<int[]>rec.get("B"))[0], 2);
     test:assertEquals((<int[]>rec.get("B"))[1], 3);
+}
+
+@test:Config{}
+function testXmlStringToRecord27() returns error? {
+    string xmlStr = string `
+    <Data>
+        <A><B>1</B></A>
+        <A><B>2</B></A>
+        <A><B>3</B></A>
+        <D>4</D>
+    </Data>`;
+
+    record {|
+        string D;
+        record {|
+            int B;
+        |}[]...;
+    |} rec = check fromXmlStringWithType(xmlStr);
+    test:assertEquals(rec.D, "4");
+    test:assertEquals((<record {|int B;|}[]>rec.get("A"))[0].B, 1);
+    test:assertEquals((<record {|int B;|}[]>rec.get("A"))[1].B, 2);
+    test:assertEquals((<record {|int B;|}[]>rec.get("A"))[2].B, 3);
+}
+
+@test:Config{}
+function testXmlToRecord27() returns error? {
+    xml xmlVal = xml `
+    <Data>
+        <A><B>1</B></A>
+        <A><B>2</B></A>
+        <A><B>3</B></A>
+        <D>4</D>
+    </Data>`;
+
+    record {|
+        string D;
+        record {|
+            int B;
+        |}[]...;
+    |} rec = check fromXmlWithType(xmlVal);
+    test:assertEquals(rec.D, "4");
+    test:assertEquals((<record {|int B;|}[]>rec.get("A"))[0].B, 1);
+    test:assertEquals((<record {|int B;|}[]>rec.get("A"))[1].B, 2);
+    test:assertEquals((<record {|int B;|}[]>rec.get("A"))[2].B, 3);
+}
+
+@test:Config{}
+function testXmlStringToRecord28() returns error? {
+    string xmlStr = string `
+        <Data>
+            <A><B>1</B></A>
+            <A><B>2</B></A>
+            <A><B>3</B></A>
+            <C><B>4</B></C>
+            <D>4</D>
+        </Data>
+    `;
+
+    record {} rec = check fromXmlStringWithType(xmlStr);
+    test:assertEquals(rec.get("D"), "4");
+    test:assertEquals(rec.get("A"), [{B: "1"}, {B: "2"}, {B: "3"}]);
+    test:assertEquals(rec.get("C"), {B: "4"});
+}
+
+@test:Config{}
+function testXmlToRecord28() returns error? {
+    xml xmlVal = xml `
+        <Data>
+            <A><B>1</B></A>
+            <A><B>2</B></A>
+            <A><B>3</B></A>
+            <C><B>4</B></C>
+            <D>4</D>
+        </Data>
+    `;
+
+    record {} rec = check fromXmlWithType(xmlVal);
+    test:assertEquals(rec.get("D"), "4");
+    test:assertEquals(rec.get("A"), [{B: "1"}, {B: "2"}, {B: "3"}]);
+    test:assertEquals(rec.get("C"), {B: "4"});
 }
 
 // test namespace and attributes annotations
@@ -1160,6 +1277,186 @@ function testSameAttributeWithDifferentNameSpace() returns error? {
     RecNs2 rec2 = check fromXmlWithType(xmlVal);
     test:assertEquals(rec2.bar, "1");
     test:assertEquals(rec2.baz, "2");
+}
+
+@test:Config{}
+function testXmlWithAttributesAgainstOpenRecord1() returns error? {
+    string xmlStr = string `<root>
+        <element1 attribute1="value1" attribute2="value2">
+            <subelement1 attribute3="value3" />
+            <subelement2 attribute4="value4" attribute5="value5" />
+        </element1>
+        <element2 attribute6="value6">
+            <subelement3 attribute7="value7" />
+        </element2>
+    </root>`;
+
+    record {} rec = check fromXmlStringWithType(xmlStr);
+    test:assertEquals(rec.length(), 2);
+    test:assertEquals(rec.get("element1"), {
+        "attribute1":"value1",
+        "attribute2":"value2",
+        "subelement1":{"attribute3":"value3"},
+        "subelement2":{"attribute4":"value4","attribute5":"value5"}}
+    );
+    test:assertEquals(rec.get("element2"), {
+        "attribute6":"value6",
+        "subelement3":{"attribute7":"value7"}}
+    );
+
+    xml xmlVal = xml `<root>
+        <element1 attribute1="value1" attribute2="value2">
+            <subelement1 attribute3="value3"/>
+            <subelement2 attribute4="value4" attribute5="value5"/>
+        </element1>
+        <element2 attribute6="value6">
+            <subelement3 attribute7="value7"/>
+        </element2>
+    </root>`;
+
+    record {} rec2 = check fromXmlWithType(xmlVal);
+    test:assertEquals(rec2.length(), 2);
+    test:assertEquals(rec2.get("element1"), {
+        "attribute1":"value1",
+        "attribute2":"value2",
+        "subelement1":{"attribute3":"value3"},
+        "subelement2":{"attribute4":"value4","attribute5":"value5"}}
+    );
+    test:assertEquals(rec2.get("element2"), {
+        "attribute6":"value6",
+        "subelement3":{"attribute7":"value7"}}
+    );
+}
+
+@test:Config{}
+function testXmlWithAttributesAgainstOpenRecord2() returns error? {
+    string xmlStr2 = string `
+        <bookstore>
+            <book ISBN="978-0-12-345678-9">
+                <title>The Example Book</title>
+                <author>
+                    <name>John Doe</name>
+                    <affiliation>Example Publications</affiliation>
+                </author>
+                <price currency="USD">19.99</price>
+            </book>
+            <book ISBN="978-0-98-765432-1">
+                <title>Another Book</title>
+                <author>
+                    <name>Jane Smith</name>
+                    <affiliation>Book World</affiliation>
+                </author>
+                <price currency="EUR">29.95</price>
+            </book>
+        </bookstore>
+    `;
+
+    record {} rec3 = check fromXmlStringWithType(xmlStr2);
+    test:assertEquals(rec3.length(), 1);
+    test:assertEquals(rec3.get("book"), [
+        {
+            "ISBN":"978-0-12-345678-9",
+            "title":"The Example Book",
+            "author":{
+                "name":"John Doe",
+                "affiliation":"Example Publications"
+            },
+            "price":{
+                "currency":"USD",
+                "#content":"19.99"
+            }
+        },
+        {
+            "ISBN":"978-0-98-765432-1",
+            "title":"Another Book",
+            "author":{
+                "name":"Jane Smith",
+                "affiliation":"Book World"
+            },
+            "price":{
+                "currency":"EUR",
+                "#content":"29.95"
+            }
+        }
+    ]);
+
+    xml xmlVal2 = xml `
+        <bookstore>
+            <book ISBN="978-0-12-345678-9">
+                <title>The Example Book</title>
+                <author>
+                    <name>John Doe</name>
+                    <affiliation>Example Publications</affiliation>
+                </author>
+                <price currency="USD">19.99</price>
+            </book>
+            <book ISBN="978-0-98-765432-1">
+                <title>Another Book</title>
+                <author>
+                    <name>Jane Smith</name>
+                    <affiliation>Book World</affiliation>
+                </author>
+                <price currency="EUR">29.95</price>
+            </book>
+        </bookstore>
+    `;
+    record {} rec4 = check fromXmlWithType(xmlVal2);
+    test:assertEquals(rec4.length(), 1);
+    test:assertEquals(rec4.get("book"), [
+        {
+            "ISBN":"978-0-12-345678-9",
+            "title":"The Example Book",
+            "author":{
+                "name":"John Doe",
+                "affiliation":"Example Publications"
+            },
+            "price":{
+                "currency":"USD",
+                "#content":"19.99"
+            }
+        },
+        {
+            "ISBN":"978-0-98-765432-1",
+            "title":"Another Book",
+            "author":{
+                "name":"Jane Smith",
+                "affiliation":"Book World"
+            },
+            "price":{
+                "currency":"EUR",
+                "#content":"29.95"
+            }
+        }
+    ]);
+}
+
+@test:Config{}
+function testXmlWithAttributesAgainstOpenRecord3() returns error? {
+    string xmlStr3 = string `<Data>
+                                <A><B value="name">1</B></A>
+                                <A><B value="name">2</B></A>
+                                <A><B value="name">3</B></A>
+                            </Data>`;
+    record {} rec5 = check fromXmlStringWithType(xmlStr3);
+    test:assertEquals(rec5.length(), 1);
+    test:assertEquals(rec5.get("A"), [
+        {"B":{"value":"name","#content":"1"}},
+        {"B":{"value":"name","#content":"2"}},
+        {"B":{"value":"name","#content":"3"}}
+    ]);
+
+    xml xmlVal3 = xml `<Data>
+                            <A><B value="name">1</B></A>
+                            <A><B value="name">2</B></A>
+                            <A><B value="name">3</B></A>
+                        </Data>`;
+    record {} rec6 = check fromXmlWithType(xmlVal3);
+    test:assertEquals(rec6.length(), 1);
+    test:assertEquals(rec6.get("A"), [
+        {"B":{"value":"name","#content":"1"}},
+        {"B":{"value":"name","#content":"2"}},
+        {"B":{"value":"name","#content":"3"}}
+    ]);
 }
 
 // Negative cases

--- a/ballerina/tests/fromXml_test.bal
+++ b/ballerina/tests/fromXml_test.bal
@@ -1171,14 +1171,14 @@ type DataN1 record {|
 function testXmlStringToRecordNegative1() {
     string xmlStr1 = "<Data><B></B></Data>";
     DataN1|error rec1 = fromXmlStringWithType(xmlStr1);
-    test:assertEquals((<error>rec1).message(), "Required field 'A' not present in XML");
+    test:assertEquals((<error>rec1).message(), "required field 'A' not present in XML");
 }
 
 @test:Config{}
 function testXmlToRecordNegative1() {
     xml xmlVal1 = xml `<Data><B></B></Data>`;
     DataN1|error rec1 = fromXmlWithType(xmlVal1);
-    test:assertEquals((<error>rec1).message(), "Required field 'A' not present in XML");
+    test:assertEquals((<error>rec1).message(), "required field 'A' not present in XML");
 }
 
 @test:Config{}
@@ -1201,28 +1201,28 @@ type DataN2 int;
 function testXmlStringToRecordNegative3() {
     string xmlStr1 = "<Data><A>1.0</A></Data>";
     DataN2|error rec1 = fromXmlStringWithType(xmlStr1);
-    test:assertEquals((<error>rec1).message(), "unsupported type expected record type but found 'DataN2'");
+    test:assertEquals((<error>rec1).message(), "unsupported type expected 'record' but found 'DataN2'");
 }
 
 @test:Config{}
 function testXmlToRecordNegative3() {
     xml xmlVal1 = xml `<Data><A>1.0</A></Data>`;
     DataN2|error rec1 = fromXmlWithType(xmlVal1);
-    test:assertEquals((<error>rec1).message(), "unsupported type: 'DataN2'");
+    test:assertEquals((<error>rec1).message(), "unsupported type expected 'record or map' but found 'DataN2'");
 }
 
 @test:Config{}
 function testXmlStringToRecordNegative4() {
     string xmlStr1 = "<Data><A>1</A><A>2</A></Data>";
     DataN1|error rec1 = fromXmlStringWithType(xmlStr1);
-    test:assertEquals((<error>rec1).message(), "Expected an 'int' value for the field 'A' found 'array' value");
+    test:assertEquals((<error>rec1).message(), "expected an 'int' value for the field 'A' found 'array' value");
 }
 
 @test:Config{}
 function testXmlToRecordNegative4() {
     xml xmlVal1 = xml `<Data><A>1</A><A>2</A></Data>`;
     DataN1|error rec1 = fromXmlWithType(xmlVal1);
-    test:assertEquals((<error>rec1).message(), "Expected an 'int' value for the field 'A' found 'array' value");
+    test:assertEquals((<error>rec1).message(), "expected an 'int' value for the field 'A' found 'array' value");
 }
 
 type DataN3 record {|
@@ -1233,14 +1233,14 @@ type DataN3 record {|
 function testXmlStringToRecordNegative5() {
     string xmlStr1 = "<Data><A>1</A><A>2</A><A>3</A></Data>";
     DataN3|error rec1 = fromXmlStringWithType(xmlStr1);
-    test:assertEquals((<error>rec1).message(), "Array size is not compatible with the expected size");
+    test:assertEquals((<error>rec1).message(), "array size is not compatible with the expected size");
 }
 
 @test:Config{}
 function testXmlToRecordNegative5() {
     xml xmlVal1 = xml `<Data><A>1</A><A>2</A><A>3</A></Data>`;
     DataN3|error rec1 = fromXmlWithType(xmlVal1);
-    test:assertEquals((<error>rec1).message(), "Array size is not compatible with the expected size");
+    test:assertEquals((<error>rec1).message(), "array size is not compatible with the expected size");
 }
 
 type DataN4 record {|
@@ -1251,14 +1251,14 @@ type DataN4 record {|
 function testXmlStringToRecordNegative6() {
     string xmlStr1 = "<Data><A>1</A><A>2</A><A>3</A></Data>";
     DataN4|error rec1 = fromXmlStringWithType(xmlStr1);
-    test:assertEquals((<error>rec1).message(), "Expected an 'string' value for the field 'A' found 'array' value");
+    test:assertEquals((<error>rec1).message(), "expected an 'string' value for the field 'A' found 'array' value");
 }
 
 @test:Config{}
 function testXmlToRecordNegative6() {
     xml xmlVal1 = xml `<Data><A>1</A><A>2</A><A>3</A></Data>`;
     DataN4|error rec1 = fromXmlWithType(xmlVal1);
-    test:assertEquals((<error>rec1).message(), "Expected an 'string' value for the field 'A' found 'array' value");
+    test:assertEquals((<error>rec1).message(), "expected an 'string' value for the field 'A' found 'array' value");
 }
 
 @Name {
@@ -1272,14 +1272,14 @@ type DataN5 record {|
 function testXmlStringToRecordNegative7() {
     string xmlStr1 = "<Data><A>1</A></Data>";
     DataN5|error rec1 = fromXmlStringWithType(xmlStr1);
-    test:assertEquals((<error>rec1).message(), "the record type name `Space` mismatch with given XML name `Data`");
+    test:assertEquals((<error>rec1).message(), "record type name 'Space' mismatch with given XML name 'Data'");
 }
 
 @test:Config{}
 function testXmlToRecordNegative7() {
     xml xmlVal1 = xml `<Data><A>1</A></Data>`;
     DataN5|error rec1 = fromXmlWithType(xmlVal1);
-    test:assertEquals((<error>rec1).message(), "the record type name `Space` mismatch with given XML name `Data`");
+    test:assertEquals((<error>rec1).message(), "record type name 'Space' mismatch with given XML name 'Data'");
 }
 
 @Namespace {
@@ -1293,14 +1293,14 @@ type DataN6 record {|
 function testXmlStringToRecordNegative8() {
     string xmlStr1 = string `<Data xmlns="www.test.com"><A>1</A></Data>`;
     DataN6|error rec1 = fromXmlStringWithType(xmlStr1);
-    test:assertEquals((<error>rec1).message(), "namespace mismatched for the type: DataN6");
+    test:assertEquals((<error>rec1).message(), "namespace mismatched for the type: 'DataN6'");
 }
 
 @test:Config{}
 function testXmlToRecordNegative8() {
     xml xmlVal1 = xml `<Data xmlns="www.test.com"><A>1</A></Data>`;
     DataN6|error rec1 = fromXmlWithType(xmlVal1);
-    test:assertEquals((<error>rec1).message(), "namespace mismatched for the type: DataN6");
+    test:assertEquals((<error>rec1).message(), "namespace mismatched for the type: 'DataN6'");
 }
 
 type DataN7 record {|
@@ -1314,14 +1314,14 @@ type DataN7 record {|
 function testXmlStringToRecordNegative9() {
     string xmlStr1 = string `<Data xmlns:ns1="www.test.com"><ns1:A>1</ns1:A></Data>`;
     DataN7|error rec1 = fromXmlStringWithType(xmlStr1);
-    test:assertEquals((<error>rec1).message(), "Required field 'A' not present in XML");
+    test:assertEquals((<error>rec1).message(), "required field 'A' not present in XML");
 }
 
 @test:Config{}
 function testXmlToRecordNegative9() {
     xml xmlVal1 = xml `<Data xmlns:ns1="www.test.com"><ns1:A>1</ns1:A></Data>`;
     DataN7|error rec1 = fromXmlWithType(xmlVal1);
-    test:assertEquals((<error>rec1).message(), "Required field 'A' not present in XML");
+    test:assertEquals((<error>rec1).message(), "required field 'A' not present in XML");
 }
 
 @Namespace {
@@ -1339,14 +1339,14 @@ type DataN8 record {|
 function testXmlStringToRecordNegative10() {
     string xmlStr1 = string `<x:foo xmlns:x="example.com"><x:bar>1</x:bar></x:foo>`;
     DataN8|error rec1 = fromXmlStringWithType(xmlStr1);
-    test:assertEquals((<error>rec1).message(), "Required field 'bar' not present in XML");
+    test:assertEquals((<error>rec1).message(), "required field 'bar' not present in XML");
 }
 
 @test:Config{}
 function testXmlToRecordNegative10() {
     xml xmlVal1 = xml `<x:foo xmlns:x="example.com"><x:bar>1</x:bar></x:foo>`;
     DataN8|error rec1 = fromXmlWithType(xmlVal1);
-    test:assertEquals((<error>rec1).message(), "Required field 'bar' not present in XML");
+    test:assertEquals((<error>rec1).message(), "required field 'bar' not present in XML");
 }
 
 @Namespace {
@@ -1370,14 +1370,14 @@ type DataN9 record {|
 function testXmlStringToRecordNegative11() {
     string xmlStr1 = string `<x:foo xmlns:x="example.com" xmlns="example2.com"><x:bar><baz>2</baz></x:bar></x:foo>`;
     DataN9|error rec1 = fromXmlStringWithType(xmlStr1);
-    test:assertEquals((<error>rec1).message(), "Required field 'baz' not present in XML");
+    test:assertEquals((<error>rec1).message(), "required field 'baz' not present in XML");
 }
 
 @test:Config{}
 function testXmlToRecordNegative11() {
     xml xmlVal1 = xml `<x:foo xmlns:x="example.com" xmlns="example2.com"><x:bar><baz>2</baz></x:bar></x:foo>`;
     DataN9|error rec1 = fromXmlWithType(xmlVal1);
-    test:assertEquals((<error>rec1).message(), "Required field 'baz' not present in XML");
+    test:assertEquals((<error>rec1).message(), "required field 'baz' not present in XML");
 }
 
 @test:Config{}
@@ -1388,7 +1388,7 @@ function testXmlStringToRecordNegative12() {
     </Data>`;
 
     RecAtt6|error rec = fromXmlStringWithType(xmlStr);
-    test:assertEquals((<error>rec).message(), "Required attribute 'data' not present in XML");
+    test:assertEquals((<error>rec).message(), "required attribute 'data' not present in XML");
 }
 
 @test:Config{}
@@ -1399,5 +1399,5 @@ function testXmlToRecordNegative12() {
     </Data>`;
 
     RecAtt6|error rec = fromXmlWithType(xmlVal);
-    test:assertEquals((<error>rec).message(), "Required attribute 'data' not present in XML");
+    test:assertEquals((<error>rec).message(), "required attribute 'data' not present in XML");
 }

--- a/native/src/main/java/io/ballerina/stdlib/data/utils/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/utils/Constants.java
@@ -55,8 +55,8 @@ public class Constants {
     public static final String CONTENT = "#content";
     public static final QualifiedName CONTENT_QNAME = new QualifiedName("", CONTENT, "");
     public static final String XMLNS = "xmlns";
+    public static final String FIELD_REGEX = "\\$field\\$\\.";
     public static final Field CONTENT_FIELD =
             TypeCreator.createField(PredefinedTypes.TYPE_ANYDATA, Constants.CONTENT, SymbolFlags.REQUIRED);
     public static final int NS_PREFIX_BEGIN_INDEX = BXmlItem.XMLNS_NS_URI_PREFIX.length();
-    public static final String NS_ANNOT_NOT_DEFINED = "$$ns_annot_not_defined$$";
 }

--- a/native/src/main/java/io/ballerina/stdlib/data/utils/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/utils/Constants.java
@@ -20,9 +20,7 @@ package io.ballerina.stdlib.data.utils;
 
 import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.creators.TypeCreator;
-import io.ballerina.runtime.api.flags.SymbolFlags;
 import io.ballerina.runtime.api.types.ArrayType;
-import io.ballerina.runtime.api.types.Field;
 import io.ballerina.runtime.api.types.MapType;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BString;
@@ -32,7 +30,7 @@ import io.ballerina.stdlib.data.xml.QualifiedName;
 /**
  * Constants used in Ballerina XmlData library.
  *
- * @since 0.1.0
+ * @since 0.0.1
  */
 public class Constants {
 
@@ -56,7 +54,8 @@ public class Constants {
     public static final QualifiedName CONTENT_QNAME = new QualifiedName("", CONTENT, "");
     public static final String XMLNS = "xmlns";
     public static final String FIELD_REGEX = "\\$field\\$\\.";
-    public static final Field CONTENT_FIELD =
-            TypeCreator.createField(PredefinedTypes.TYPE_ANYDATA, Constants.CONTENT, SymbolFlags.REQUIRED);
     public static final int NS_PREFIX_BEGIN_INDEX = BXmlItem.XMLNS_NS_URI_PREFIX.length();
+    public static final String RECORD = "record";
+    public static final String RECORD_OR_MAP = "record or map";
+    public static final String ANON_TYPE = "$anonType$";
 }

--- a/native/src/main/java/io/ballerina/stdlib/data/utils/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/utils/Constants.java
@@ -27,6 +27,7 @@ import io.ballerina.runtime.api.types.MapType;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.api.values.BXmlItem;
+import io.ballerina.stdlib.data.xml.QualifiedName;
 
 /**
  * Constants used in Ballerina XmlData library.
@@ -44,7 +45,7 @@ public class Constants {
     public static final ArrayType ANYDATA_ARRAY_TYPE = TypeCreator.createArrayType(PredefinedTypes.TYPE_ANYDATA);
     public static final MapType ANYDATA_MAP_TYPE = TypeCreator.createMapType(PredefinedTypes.TYPE_ANYDATA);
     public static final String FIELD = "$field$.";
-    public static final String NAME_SPACE = "Namespace";
+    public static final String NAMESPACE = "Namespace";
     public static final BString URI = StringUtils.fromString("uri");
     public static final BString PREFIX = StringUtils.fromString("prefix");
     public static final String ATTRIBUTE = "Attribute";
@@ -52,8 +53,10 @@ public class Constants {
     public static final String NAME = "Name";
     public static final BString VALUE = StringUtils.fromString("value");
     public static final String CONTENT = "#content";
+    public static final QualifiedName CONTENT_QNAME = new QualifiedName("", CONTENT, "");
     public static final String XMLNS = "xmlns";
     public static final Field CONTENT_FIELD =
             TypeCreator.createField(PredefinedTypes.TYPE_ANYDATA, Constants.CONTENT, SymbolFlags.REQUIRED);
     public static final int NS_PREFIX_BEGIN_INDEX = BXmlItem.XMLNS_NS_URI_PREFIX.length();
+    public static final String NS_ANNOT_NOT_DEFINED = "$$ns_annot_not_defined$$";
 }

--- a/native/src/main/java/io/ballerina/stdlib/data/utils/DataUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/utils/DataUtils.java
@@ -282,6 +282,18 @@ public class DataUtils {
         return typeTag == TypeTags.STRING_TAG || typeTag == TypeTags.ANYDATA_TAG || typeTag == TypeTags.JSON_TAG;
     }
 
+    public static ArrayType getValidArrayType(Type type) {
+        switch (type.getTag()) {
+            case TypeTags.ARRAY_TAG:
+                return (ArrayType) type;
+            case TypeTags.ANYDATA_TAG:
+                return PredefinedTypes.TYPE_ANYDATA_ARRAY;
+            case TypeTags.JSON_TAG:
+                return PredefinedTypes.TYPE_JSON_ARRAY;
+        }
+        return null;
+    }
+
     public static void updateExpectedTypeStacks(RecordType recordType, XmlAnalyzerData analyzerData) {
         analyzerData.attributeHierarchy.push(new HashMap<>(getAllAttributesInRecordType(recordType)));
         analyzerData.fieldHierarchy.push(new HashMap<>(getAllFieldsInRecordType(recordType, analyzerData)));

--- a/native/src/main/java/io/ballerina/stdlib/data/utils/DataUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/utils/DataUtils.java
@@ -100,7 +100,7 @@ public class DataUtils {
                         prefix == null ? "" : prefix.getValue());
             }
         }
-        return new QualifiedName(Constants.NS_ANNOT_NOT_DEFINED, recordName, "");
+        return new QualifiedName(QualifiedName.NS_ANNOT_NOT_DEFINED, recordName, "");
     }
 
     public static void validateTypeNamespace(String prefix, String uri, RecordType recordType) {
@@ -160,7 +160,8 @@ public class DataUtils {
         Map<String, Field> recordFields = recordType.getFields();
         for (String key : recordFields.keySet()) {
             QualifiedName modifiedQName =
-                    modifiedNames.getOrDefault(key, new QualifiedName(Constants.NS_ANNOT_NOT_DEFINED, key, ""));
+                    modifiedNames.getOrDefault(key,
+                            new QualifiedName(QualifiedName.NS_ANNOT_NOT_DEFINED, key, ""));
             if (fields.containsKey(modifiedQName)) {
                 throw DataUtils.getXmlError("Duplicate field '" + modifiedQName.getLocalPart() + "'");
             } else if (analyzerData.attributeHierarchy.peek().containsKey(modifiedQName)) {
@@ -199,7 +200,7 @@ public class DataUtils {
                         prefix == null ? "" : prefix.getValue());
             }
         }
-        return new QualifiedName(Constants.NS_ANNOT_NOT_DEFINED, fieldName, "");
+        return new QualifiedName(QualifiedName.NS_ANNOT_NOT_DEFINED, fieldName, "");
     }
 
     @SuppressWarnings("unchecked")

--- a/native/src/main/java/io/ballerina/stdlib/data/utils/DataUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/utils/DataUtils.java
@@ -37,6 +37,7 @@ import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.stdlib.data.FromString;
+import io.ballerina.stdlib.data.xml.QualifiedName;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -69,62 +70,37 @@ public class DataUtils {
                 null, null);
     }
 
-    public static String validateAndGetXmlNameFromRecordAnnotation(RecordType recordType, String recordName,
-                                                             String elementName) {
+    @SuppressWarnings("unchecked")
+    public static QualifiedName validateAndGetXmlNameFromRecordAnnotation(RecordType recordType, String recordName,
+                                                                          QualifiedName elementName) {
         BMap<BString, Object> annotations = recordType.getAnnotations();
         for (BString annotationsKey : annotations.getKeys()) {
             String key = annotationsKey.getValue();
             if (!key.contains(Constants.FIELD) && key.endsWith(Constants.NAME)) {
                 String name = ((BMap<BString, Object>) annotations.get(annotationsKey)).get(Constants.VALUE).toString();
-                if (!name.equals(elementName)) {
+                String localPart = elementName.getLocalPart();
+                if (!name.equals(localPart)) {
                     throw DataUtils.getXmlError("the record type name `" + name +
-                            "` mismatch with given XML name `" + elementName + "`");
+                            "` mismatch with given XML name `" + localPart + "`");
                 }
-                return name;
-            }
-        }
-        return recordName;
-    }
-
-    public static void validateFieldNamespace(String prefix, String uri, String fieldName, RecordType recordType) {
-        ArrayList<String> namespace = getFieldNamespace(recordType, fieldName);
-
-        if (namespace.isEmpty()) {
-            return;
-        }
-
-        if (prefix.equals(namespace.get(0)) && uri.equals(namespace.get(1))) {
-            return;
-        }
-        throw DataUtils.getXmlError("namespace mismatched for the field: " + fieldName);
-    }
-
-    public static ArrayList<String> getFieldNamespace(RecordType recordType, String fieldName) {
-        BMap<BString, Object> annotations = recordType.getAnnotations();
-        String namespacePrefix = null;
-        String namespaceUri = null;
-        for (BString annotationsKey : annotations.getKeys()) {
-            String key = annotationsKey.getValue();
-            if (key.contains(Constants.FIELD) && key.split("\\$field\\$\\.")[1].equals(fieldName)) {
-                BMap<BString, Object> namespaceAnnotation = (BMap<BString, Object>) annotations.get(annotationsKey);
-                for (BString keyStr : namespaceAnnotation.getKeys()) {
-                    if (keyStr.getValue().endsWith(Constants.NAME_SPACE)) {
-                        namespaceAnnotation = (BMap<BString, Object>) namespaceAnnotation.get(keyStr);
-                        namespacePrefix = namespaceAnnotation.containsKey(Constants.PREFIX) ?
-                                ((BString) namespaceAnnotation.get(Constants.PREFIX)).getValue() : "";
-                        namespaceUri = ((BString) namespaceAnnotation.get(Constants.URI)).getValue();
-                        break;
-                    }
-                }
+                recordName = name;
                 break;
             }
         }
-        ArrayList<String> namespace = new ArrayList<>();
-        if (namespacePrefix != null && namespaceUri != null) {
-            namespace.add(namespacePrefix);
-            namespace.add(namespaceUri);
+
+        // Handle the namespace annotation.
+        for (BString annotationsKey : annotations.getKeys()) {
+            String key = annotationsKey.getValue();
+            if (!key.contains(Constants.FIELD) && key.endsWith(Constants.NAMESPACE)) {
+                Map<BString, Object> namespaceAnnotation =
+                        ((Map<BString, Object>) annotations.get(StringUtils.fromString(key)));
+                BString uri = (BString) namespaceAnnotation.get(Constants.URI);
+                BString prefix = (BString) namespaceAnnotation.get(Constants.PREFIX);
+                return new QualifiedName(uri == null ? "" : uri.getValue(), recordName,
+                        prefix == null ? "" : prefix.getValue());
+            }
         }
-        return namespace;
+        return new QualifiedName(Constants.NS_ANNOT_NOT_DEFINED, recordName, "");
     }
 
     public static void validateTypeNamespace(String prefix, String uri, RecordType recordType) {
@@ -140,13 +116,14 @@ public class DataUtils {
         throw DataUtils.getXmlError("namespace mismatched for the type: " + recordType.getName());
     }
 
+    @SuppressWarnings("unchecked")
     private static ArrayList<String> getNamespace(RecordType recordType) {
         BMap<BString, Object> annotations = recordType.getAnnotations();
         String namespacePrefix = null;
         String namespaceUri = null;
         for (BString annotationsKey : annotations.getKeys()) {
             String key = annotationsKey.getValue();
-            if (!key.contains(Constants.FIELD) && key.endsWith(Constants.NAME_SPACE)) {
+            if (!key.contains(Constants.FIELD) && key.endsWith(Constants.NAMESPACE)) {
                 BMap<BString, Object> namespaceAnnotation = (BMap<BString, Object>) annotations.get(annotationsKey);
                 namespacePrefix = namespaceAnnotation.containsKey(Constants.PREFIX) ?
                         ((BString) namespaceAnnotation.get(Constants.PREFIX)).getValue() : "";
@@ -162,48 +139,70 @@ public class DataUtils {
         return namespace;
     }
 
-    public static Map<String, Field> getAllFieldsInRecordType(RecordType recordType, XmlAnalyzerData analyzerData) {
+    @SuppressWarnings("unchecked")
+    public static Map<QualifiedName, Field> getAllFieldsInRecordType(RecordType recordType,
+                                                                     XmlAnalyzerData analyzerData) {
         BMap<BString, Object> annotations = recordType.getAnnotations();
-        HashMap<String, String> modifiedNames = new LinkedHashMap<>();
+        HashMap<String, QualifiedName> modifiedNames = new LinkedHashMap<>();
         for (BString annotationKey : annotations.getKeys()) {
             String keyStr = annotationKey.getValue();
             if (keyStr.contains(Constants.FIELD)) {
-                String elementName = keyStr.split("\\$field\\$\\.")[1].replaceAll("\\\\", "");
+                // Capture namespace and name from the field annotation.
+                String fieldName = keyStr.split("\\$field\\$\\.")[1].replaceAll("\\\\", "");
                 Map<BString, Object> fieldAnnotation = (Map<BString, Object>) annotations.get(annotationKey);
-                modifiedNames.put(elementName, getModifiedName(fieldAnnotation, elementName));
+                QualifiedName fieldQName = DataUtils.getFieldNameFromRecord(fieldAnnotation, fieldName);
+                fieldQName.setLocalPart(getModifiedName(fieldAnnotation, fieldName));
+                modifiedNames.put(fieldName, fieldQName);
             }
         }
 
-        Map<String, Field> fields = new HashMap<>();
+        Map<QualifiedName, Field> fields = new HashMap<>();
         Map<String, Field> recordFields = recordType.getFields();
         for (String key : recordFields.keySet()) {
-            if (analyzerData.attributeHierarchy.peek().containsKey(key)) {
+            QualifiedName modifiedQName =
+                    modifiedNames.getOrDefault(key, new QualifiedName(Constants.NS_ANNOT_NOT_DEFINED, key, ""));
+            if (fields.containsKey(modifiedQName)) {
+                throw DataUtils.getXmlError("Duplicate field '" + modifiedQName.getLocalPart() + "'");
+            } else if (analyzerData.attributeHierarchy.peek().containsKey(modifiedQName)) {
                 continue;
             }
-            fields.put(modifiedNames.getOrDefault(key, key), recordFields.get(key));
+            fields.put(modifiedQName, recordFields.get(key));
         }
         return fields;
     }
 
-    public static Map<String, Field> getAllAttributesInRecordType(RecordType recordType) {
+    @SuppressWarnings("unchecked")
+    public static Map<QualifiedName, Field> getAllAttributesInRecordType(RecordType recordType) {
         BMap<BString, Object> annotations = recordType.getAnnotations();
-        Map<String, Field> attributes = new HashMap<>();
+        Map<QualifiedName, Field> attributes = new HashMap<>();
         for (BString annotationKey : annotations.getKeys()) {
             String keyStr = annotationKey.getValue();
-            if (keyStr.contains(Constants.FIELD)) {
+            if (keyStr.contains(Constants.FIELD) && DataUtils.isAttributeField(annotationKey, annotations)) {
                 String attributeName = keyStr.split("\\$field\\$\\.")[1].replaceAll("\\\\", "");
                 Map<BString, Object> fieldAnnotation = (Map<BString, Object>) annotations.get(annotationKey);
-                for (BString key : fieldAnnotation.keySet()) {
-                    if (key.getValue().endsWith(Constants.ATTRIBUTE)) {
-                        attributes.put(getModifiedName(fieldAnnotation, attributeName),
-                                recordType.getFields().get(attributeName));
-                    }
-                }
+                QualifiedName fieldQName = getFieldNameFromRecord(fieldAnnotation, attributeName);
+                fieldQName.setLocalPart(getModifiedName(fieldAnnotation, attributeName));
+                attributes.put(fieldQName, recordType.getFields().get(attributeName));
             }
         }
         return attributes;
     }
 
+    @SuppressWarnings("unchecked")
+    public static QualifiedName getFieldNameFromRecord(Map<BString, Object> fieldAnnotation, String fieldName) {
+        for (BString key : fieldAnnotation.keySet()) {
+            if (key.getValue().endsWith(Constants.NAMESPACE)) {
+                Map<BString, Object> namespaceAnnotation = ((Map<BString, Object>) fieldAnnotation.get(key));
+                BString uri = (BString) namespaceAnnotation.get(Constants.URI);
+                BString prefix = (BString) namespaceAnnotation.get(Constants.PREFIX);
+                return new QualifiedName(uri == null ? "" : uri.getValue(), fieldName,
+                        prefix == null ? "" : prefix.getValue());
+            }
+        }
+        return new QualifiedName(Constants.NS_ANNOT_NOT_DEFINED, fieldName, "");
+    }
+
+    @SuppressWarnings("unchecked")
     private static String getModifiedName(Map<BString, Object> fieldAnnotation, String attributeName) {
         for (BString key : fieldAnnotation.keySet()) {
             if (key.getValue().endsWith(Constants.NAME)) {
@@ -217,8 +216,8 @@ public class DataUtils {
         return ValueCreator.createArrayValue(Constants.ANYDATA_ARRAY_TYPE);
     }
 
-    public static String getElementName(QName qName) {
-        return qName.getLocalPart();
+    public static QualifiedName getElementName(QName qName) {
+        return new QualifiedName(qName.getNamespaceURI(), qName.getLocalPart(), qName.getPrefix());
     }
 
     public static Object convertStringToExpType(BString value, Type expType) {
@@ -244,8 +243,8 @@ public class DataUtils {
     }
 
     public static void validateRequiredFields(BMap<BString, Object> currentMapValue, XmlAnalyzerData analyzerData) {
-        Map<String, Field> fields = analyzerData.fieldHierarchy.peek();
-        for (String key : fields.keySet()) {
+        Map<QualifiedName, Field> fields = analyzerData.fieldHierarchy.peek();
+        for (QualifiedName key : fields.keySet()) {
             // Validate required array size
             Field field = fields.get(key);
             String fieldName = field.getFieldName();
@@ -264,8 +263,8 @@ public class DataUtils {
             }
         }
 
-        Map<String, Field> attributes = analyzerData.attributeHierarchy.peek();
-        for (String key : attributes.keySet()) {
+        Map<QualifiedName, Field> attributes = analyzerData.attributeHierarchy.peek();
+        for (QualifiedName key : attributes.keySet()) {
             Field field = attributes.get(key);
             String fieldName = field.getFieldName();
             if (!SymbolFlags.isFlagOn(field.getFlags(), SymbolFlags.OPTIONAL)) {
@@ -373,6 +372,7 @@ public class DataUtils {
         return recordValue;
     }
 
+    @SuppressWarnings("unchecked")
     private static QName addFieldNamespaceAnnotation(String key, BMap<BString, Object> annotations,
                                                     BMap<BString, Object> recordValue) {
         BString annotationKey =
@@ -381,7 +381,7 @@ public class DataUtils {
         if (annotations.containsKey(annotationKey)) {
             BMap<BString, Object> annotationValue = (BMap<BString, Object>) annotations.get(annotationKey);
             for (BString fieldKey : annotationValue.getKeys()) {
-                if (fieldKey.toString().endsWith(Constants.NAME_SPACE)) {
+                if (fieldKey.toString().endsWith(Constants.NAMESPACE)) {
                     return processFieldNamespaceAnnotation(annotationValue, key, fieldKey, recordValue,
                             isAttributeField);
                 }
@@ -390,7 +390,8 @@ public class DataUtils {
         return new QName("", key, "");
     }
 
-    private static boolean isAttributeField(BString annotationKey, BMap<BString, Object> annotations) {
+    @SuppressWarnings("unchecked")
+    public static boolean isAttributeField(BString annotationKey, BMap<BString, Object> annotations) {
         if (annotations.containsKey(annotationKey)) {
             BMap<BString, Object> annotationValue = (BMap<BString, Object>) annotations.get(annotationKey);
             for (BString fieldKey : annotationValue.getKeys()) {
@@ -402,6 +403,7 @@ public class DataUtils {
         return false;
     }
 
+    @SuppressWarnings("unchecked")
     private static BMap<BString, Object> getFieldNamespaceAndNameAnnotations(String key,
                                                                              BMap<BString, Object> parentAnnotations) {
         BMap<BString, Object> nsFieldAnnotation = ValueCreator.createMapValue(Constants.JSON_MAP_TYPE);
@@ -411,7 +413,7 @@ public class DataUtils {
             BMap<BString, Object> annotationValue = (BMap<BString, Object>) parentAnnotations.get(annotationKey);
             for (BString fieldKey : annotationValue.getKeys()) {
                 String keyName = fieldKey.getValue();
-                if (keyName.endsWith(Constants.NAME_SPACE) || keyName.endsWith(Constants.NAME)) {
+                if (keyName.endsWith(Constants.NAMESPACE) || keyName.endsWith(Constants.NAME)) {
                     nsFieldAnnotation.put(fieldKey, annotationValue.get(fieldKey));
                     break;
                 }
@@ -452,7 +454,7 @@ public class DataUtils {
         BMap<BString, Object> currentValue;
         if (record.containsKey(key)) {
             currentValue = (BMap<BString, Object>) record.get(key);
-            key = StringUtils.fromString("#content");
+            key = StringUtils.fromString(Constants.CONTENT);
         } else {
             currentValue = record;
         }
@@ -571,7 +573,7 @@ public class DataUtils {
                 if (stringValue.endsWith(Constants.NAME)) {
                     key = processNameAnnotation(annotation, key, value, hasNamespaceAnnotation);
                 }
-                if (stringValue.endsWith(Constants.NAME_SPACE)) {
+                if (stringValue.endsWith(Constants.NAMESPACE)) {
                     hasNamespaceAnnotation = true;
                     key = processNamespaceAnnotation(annotation, key, value, namespaces);
                 }
@@ -584,7 +586,7 @@ public class DataUtils {
                                                    BMap<BString, Object>  subRecord) {
         BString[] keys = annotation.getKeys();
         for (BString value : keys) {
-            if (value.getValue().endsWith(Constants.NAME_SPACE)) {
+            if (value.getValue().endsWith(Constants.NAMESPACE)) {
                 processNamespaceAnnotation(annotation, "", value, subRecord);
             }
         }
@@ -595,7 +597,7 @@ public class DataUtils {
         BString[] keys = annotation.getKeys();
         boolean hasNamespaceAnnotation = false;
         for (BString value : keys) {
-            if (value.getValue().endsWith(Constants.NAME_SPACE)) {
+            if (value.getValue().endsWith(Constants.NAMESPACE)) {
                 hasNamespaceAnnotation = true;
                 BMap<BString, Object> namespaceAnnotation = (BMap<BString, Object>) annotation.get(value);
                 BString prefix = (BString) namespaceAnnotation.get(Constants.PREFIX);
@@ -672,11 +674,11 @@ public class DataUtils {
      */
     public static class XmlAnalyzerData {
         public final Stack<Object> nodesStack = new Stack<>();
-        public final Stack<Map<String, Field>> fieldHierarchy = new Stack<>();
-        public final Stack<Map<String, Field>> attributeHierarchy = new Stack<>();
+        public final Stack<Map<QualifiedName, Field>> fieldHierarchy = new Stack<>();
+        public final Stack<Map<QualifiedName, Field>> attributeHierarchy = new Stack<>();
         public final Stack<Type> restTypes = new Stack<>();
         public RecordType rootRecord;
         public Field currentField;
-        public String rootElement;
+        public QualifiedName rootElement;
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/data/utils/DiagnosticErrorCode.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/utils/DiagnosticErrorCode.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.data.utils;
+
+/**
+ * Represents a diagnostic error code.
+ *
+ * @since 0.0.1
+ */
+public enum DiagnosticErrorCode {
+
+    UNSUPPORTED_TYPE("BDE_0001", "unsupported.type"),
+    XML_ROOT_MISSING("BDE_0002", "xml.root.missing"),
+    INVALID_REST_TYPE("BDE_0003", "invalid.rest.type"),
+    ARRAY_SIZE_MISMATCH("BDE_0004", "array.size.mismatch"),
+    REQUIRED_FIELD_NOT_PRESENT("BDE_0005", "required.field.not.present"),
+    REQUIRED_ATTRIBUTE_NOT_PRESENT("BDE_0006", "required.attribute.not.present"),
+    DUPLICATE_FIELD("BDE_0007", "duplicate.field"),
+    FOUND_ARRAY_FOR_NON_ARRAY_TYPE("BDE_0008", "found.array.for.non.array.type"),
+    EXPECTED_ANYDATA_OR_JSON("BDE_0009", "expected.anydata.or.json"),
+    NAMESPACE_MISMATCH("BDE_0010", "namespace.mismatch"),
+    TYPE_NAME_MISMATCH_WITH_XML_ELEMENT("BDE_0011", "type.name.mismatch.with.xml.element");
+
+    String diagnosticId;
+    String messageKey;
+
+    DiagnosticErrorCode(String diagnosticId, String messageKey) {
+        this.diagnosticId = diagnosticId;
+        this.messageKey = messageKey;
+    }
+
+    public String messageKey() {
+        return messageKey;
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/data/utils/DiagnosticLog.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/utils/DiagnosticLog.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.data.utils;
+
+import io.ballerina.runtime.api.creators.ErrorCreator;
+import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.values.BError;
+
+import java.text.MessageFormat;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+/**
+ * Diagnostic log for data module.
+ *
+ * @since 0.0.1
+ */
+public class DiagnosticLog {
+    private static final String ERROR_PREFIX = "error";
+    private static final String ERROR = "ConversionError";
+    private static final ResourceBundle MESSAGES = ResourceBundle.getBundle("error", Locale.getDefault());
+
+    public static BError error(DiagnosticErrorCode code, Object... args) {
+        String msg = formatMessage(code, args);
+        return getXmlError(msg);
+    }
+
+    private static String formatMessage(DiagnosticErrorCode code, Object[] args) {
+        String msgKey = MESSAGES.getString(ERROR_PREFIX + "." + code.messageKey());
+        return MessageFormat.format(msgKey, args);
+    }
+
+    public static BError getXmlError(String message) {
+        return ErrorCreator.createError(ModuleUtils.getModule(), ERROR, StringUtils.fromString(message),
+                null, null);
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/data/utils/ModuleUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/utils/ModuleUtils.java
@@ -24,7 +24,7 @@ import io.ballerina.runtime.api.Module;
 /**
  * This class will hold module related utility functions.
  *
- * @since 0.1.0
+ * @since 0.0.1
  */
 public class ModuleUtils {
 

--- a/native/src/main/java/io/ballerina/stdlib/data/xml/BallerinaByteBlockInputStream.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/xml/BallerinaByteBlockInputStream.java
@@ -40,7 +40,7 @@ import java.util.function.Consumer;
 /**
  * Java Input Stream based on Ballerina byte block stream. <code>stream<byte[], error?></code>
  *
- * @since 0.1.0
+ * @since 0.0.1
  */
 public class BallerinaByteBlockInputStream extends InputStream {
 

--- a/native/src/main/java/io/ballerina/stdlib/data/xml/Native.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/xml/Native.java
@@ -30,6 +30,7 @@ import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.api.values.BXml;
 import io.ballerina.stdlib.data.utils.DataUtils;
+import io.ballerina.stdlib.data.utils.DiagnosticLog;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
@@ -39,7 +40,7 @@ import java.util.function.Consumer;
 /**
  * Xml conversion.
  *
- * @since 0.1.0
+ * @since 0.0.1
  */
 public class Native {
 
@@ -50,7 +51,7 @@ public class Native {
         try {
             return XmlTraversal.traverse(xml, typed.getDescribingType());
         } catch (Exception e) {
-            return DataUtils.getXmlError(e.getMessage());
+            return DiagnosticLog.getXmlError(e.getMessage());
         }
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/data/xml/QualifiedName.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/xml/QualifiedName.java
@@ -1,7 +1,29 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package io.ballerina.stdlib.data.xml;
 
+/**
+ * Represents a qualified name.
+ *
+ * @since 0.1.0
+ */
 public class QualifiedName {
-    private static final String NS_ANNOT_NOT_DEFINED = "$$ns_annot_not_defined$$";
+    public static final String NS_ANNOT_NOT_DEFINED = "$$ns_annot_not_defined$$";
     private String localPart;
     private String namespaceURI;
     private String prefix;

--- a/native/src/main/java/io/ballerina/stdlib/data/xml/QualifiedName.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/xml/QualifiedName.java
@@ -20,7 +20,7 @@ package io.ballerina.stdlib.data.xml;
 /**
  * Represents a qualified name.
  *
- * @since 0.1.0
+ * @since 0.0.1
  */
 public class QualifiedName {
     public static final String NS_ANNOT_NOT_DEFINED = "$$ns_annot_not_defined$$";

--- a/native/src/main/java/io/ballerina/stdlib/data/xml/QualifiedName.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/xml/QualifiedName.java
@@ -1,0 +1,60 @@
+package io.ballerina.stdlib.data.xml;
+
+public class QualifiedName {
+    private static final String NS_ANNOT_NOT_DEFINED = "$$ns_annot_not_defined$$";
+    private String localPart;
+    private String namespaceURI;
+    private String prefix;
+
+    public QualifiedName(String namespaceURI, String localPart, String prefix) {
+        this.localPart = localPart;
+        this.namespaceURI = namespaceURI;
+        this.prefix = prefix;
+    }
+
+    public QualifiedName(String localPart) {
+        this.localPart = localPart;
+        this.namespaceURI = "";
+        this.prefix = "";
+    }
+
+    public String getLocalPart() {
+        return localPart;
+    }
+
+    public void setLocalPart(String localPart) {
+        this.localPart = localPart;
+    }
+
+    public String getNamespaceURI() {
+        return namespaceURI;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    @Override
+    public int hashCode() {
+        return localPart.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object objectToTest) {
+        if (objectToTest == this) {
+            return true;
+        }
+
+        if (objectToTest == null || !(objectToTest instanceof QualifiedName)) {
+            return false;
+        }
+
+        QualifiedName qName = (QualifiedName) objectToTest;
+
+        if (qName.namespaceURI.equals(NS_ANNOT_NOT_DEFINED) || namespaceURI.equals(NS_ANNOT_NOT_DEFINED)) {
+            return localPart.equals(qName.localPart);
+        }
+        return localPart.equals(qName.localPart) && namespaceURI.equals(qName.namespaceURI) &&
+                prefix.equals(qName.prefix);
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/data/xml/XmlTraversal.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/xml/XmlTraversal.java
@@ -141,6 +141,7 @@ public class XmlTraversal {
                     ((BArray) value).append(convertedValue);
                 } else {
                     BArray array = DataUtils.createNewAnydataList(fieldType);
+                    array.append(value);
                     array.append(convertedValue);
                     mapValue.put(fieldName, array);
                 }

--- a/native/src/main/java/io/ballerina/stdlib/data/xml/XmlTraversal.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/xml/XmlTraversal.java
@@ -93,7 +93,7 @@ public class XmlTraversal {
         private Object traverseXml(BXml xml, Type type, XmlAnalyzerData analyzerData) {
             switch (xml.getNodeType()) {
                 case ELEMENT:
-                    convertElement((BXmlItem) xml, type, analyzerData);
+                    convertElement((BXmlItem) xml, analyzerData);
                     break;
                 case SEQUENCE:
                     convertSequence((BXmlSequence) xml, type, analyzerData);
@@ -150,7 +150,7 @@ public class XmlTraversal {
         }
 
         @SuppressWarnings("unchecked")
-        private void convertElement(BXmlItem xmlItem, Type type, XmlAnalyzerData analyzerData) {
+        private void convertElement(BXmlItem xmlItem, XmlAnalyzerData analyzerData) {
             QualifiedName elementName = DataUtils.getElementName(xmlItem.getQName());
             Field currentField = analyzerData.fieldHierarchy.peek().get(elementName);
             analyzerData.currentField = currentField;

--- a/native/src/main/resources/error.properties
+++ b/native/src/main/resources/error.properties
@@ -1,0 +1,54 @@
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# -------------------------
+# Data module error messages
+# -------------------------
+
+error.unsupported.type=\
+  unsupported type expected ''{0}'' but found ''{1}''
+
+error.xml.root.missing=\
+  xml root element is missing
+
+error.invalid.rest.type=\
+  invalid rest type ''{0}''
+
+error.array.size.mismatch=\
+  array size is not compatible with the expected size
+
+error.required.field.not.present=\
+  required field ''{0}'' not present in XML
+
+error.required.attribute.not.present=\
+  required attribute ''{0}'' not present in XML
+
+error.duplicate.field=\
+  duplicate field ''{0}''
+
+error.found.array.for.non.array.type=\
+  expected an ''{0}'' value for the field ''{1}'' found ''array'' value
+
+error.expected.anydata.or.json=\
+  incompatible type expected anydata or json
+
+error.namespace.mismatch=\
+  namespace mismatched for the type: ''{0}''
+
+error.type.name.mismatch.with.xml.element=\
+  record type name ''{0}'' mismatch with given XML name ''{1}''


### PR DESCRIPTION
Handle cases such as below

```
type RecNs2 record {|
    @Namespace {
        prefix: "x",
        uri: "example.com"
    }
    string bar;
    @Name {
        value: "bar"
    }
    @Namespace {
        prefix: "y",
        uri: "example2.com"
    }
    string baz;
|};

function testSameElementWithDifferentNameSpace() returns error? {
    string xmlStr = string `<x:foo xmlns:x="example.com" xmlns:y="example2.com" ><x:bar>1</x:bar><y:bar>2</y:bar></x:foo>`;
    RecNs2 rec = check fromXmlStringWithType(xmlStr);
}
```